### PR TITLE
Fix the UI bugs for the address checking and Set Signer List

### DIFF
--- a/js/mywallet.js
+++ b/js/mywallet.js
@@ -1314,6 +1314,9 @@ walletApp.controller('walletCtrl', ['$scope', '$http', '$uibModal', '$localStora
 
   $scope.isFederation = function (address) {
     // checking for email type address (e.g.xyz@domain.com)
+    if (typeof address === 'undefined') {
+      return true;
+    }
     return address.search(/@([\w-]+\.)+[\w-]{2,}$/) > 0;  
   }
 

--- a/templetes/modal-set-signer-list.html
+++ b/templetes/modal-set-signer-list.html
@@ -20,7 +20,7 @@
                                     <span style="color:red" ng-show="setSignerListForm.signerAddress{{$index}}.$error.rippleValidAddress">Invalid Address!</span>
                                   </td>
                                   <td style="text-align: center">
-                                    <input type="text" min=1 ng-model="options.signers[$index].weight" size="5" name="signerWeight{{$index}}" uint32 required>
+                                    <input type="number" min=1 ng-model="options.signers[$index].weight" size="5" name="signerWeight{{$index}}" uint32 required>
                                     <span style="color:red" ng-show="setSignerListForm.signerWeight{{$index}}.$dirty && setSignerListForm.signerWeight{{$index}}.$invalid">Invalid Value!</span>
                                   </td>
                                   <td><button class="btn btn-link" ng-click="options.signers.splice($index,1)"><span class="glyphicon glyphicon-trash"></span></button></td>                      


### PR DESCRIPTION
- add a checker function in isFederation method to suppress the console log error, since the 'ng-disabled' invokes the isFederation method even if the address is empty.
- change the input type to number to fix the data type error for the signer.weight
