### PR TITLE
Use 'https' for the link to the demo site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Clone/download/fork the codes, and deploy onto a web server.
 Or, simply open the index.html in browser for local usage.
 
 ### Demo
-[http://ripplerm.github.io/ripple-wallet/](http://ripplerm.github.io/ripple-wallet/)
+[https://ripplerm.github.io/ripple-wallet/](http://ripplerm.github.io/ripple-wallet/)
 
 ### License
 MIT  


### PR DESCRIPTION
In addition to this PR, `Enforce HTTPS` should be enabled.

See: https://help.github.com/en/articles/securing-your-github-pages-site-with-https